### PR TITLE
fix: Update MDX component props and use dynamic viewport height

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -150,15 +150,16 @@ export default async function BlogPostPage({
             source={content} 
             components={{ 
               CodeBlock,
-              pre: (props: any) => {
-                const code = props.children?.props?.children;
-                const lang = props.children?.props?.className?.replace('language-', '');
+              pre: (props: React.HTMLAttributes<HTMLPreElement>) => {
+                const children = props.children as React.ReactElement<{ children: string; className?: string }>;
+                const code = children?.props?.children;
+                const lang = children?.props?.className?.replace('language-', '');
                 if (lang === 'mermaid') {
                   return <div className="mermaid">{code}</div>;
                 }
                 return <pre {...props} />;
               },
-              table: (props: any) => <div className="overflow-x-auto"><table {...props} /></div>
+              table: (props: React.HTMLAttributes<HTMLTableElement>) => <div className="overflow-x-auto"><table {...props} /></div>
             }} 
           />
         </div>

--- a/src/app/experience/[slug]/page.tsx
+++ b/src/app/experience/[slug]/page.tsx
@@ -121,15 +121,16 @@ export default async function ExperienceDetailPage({
             source={content} 
             components={{ 
               CodeBlock,
-              pre: (props: any) => {
-                const code = props.children?.props?.children;
-                const lang = props.children?.props?.className?.replace('language-', '');
+              pre: (props: React.HTMLAttributes<HTMLPreElement>) => {
+                const children = props.children as React.ReactElement<{ children: string; className?: string }>;
+                const code = children?.props?.children;
+                const lang = children?.props?.className?.replace('language-', '');
                 if (lang === 'mermaid') {
                   return <div className="mermaid">{code}</div>;
                 }
                 return <pre {...props} />;
               },
-              table: (props: any) => <div className="overflow-x-auto"><table {...props} /></div>
+              table: (props: React.HTMLAttributes<HTMLTableElement>) => <div className="overflow-x-auto"><table {...props} /></div>
             }} 
           />
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,7 +123,7 @@
   }
   html,
   body {
-    @apply h-full overflow-hidden;
+    @apply h-dvh overflow-hidden;
   }
 }
 

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -146,9 +146,10 @@ export default async function ProjectDetailPage({
             options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
             components={{
               CodeBlock,
-              pre: (props: any) => {
-                const code = props.children?.props?.children;
-                const lang = props.children?.props?.className?.replace(
+              pre: (props: React.HTMLAttributes<HTMLPreElement>) => {
+                const children = props.children as React.ReactElement<{ children: string; className?: string }>;
+                const code = children?.props?.children;
+                const lang = children?.props?.className?.replace(
                   "language-",
                   "",
                 );
@@ -157,7 +158,7 @@ export default async function ProjectDetailPage({
                 }
                 return <pre {...props} />;
               },
-              table: (props: any) => (
+              table: (props: React.HTMLAttributes<HTMLTableElement>) => (
                 <div className="overflow-x-auto">
                   <table {...props} />
                 </div>

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -5,7 +5,7 @@ import DotPattern from "./ui/aceternity/dot-pattern";
 
 export default function PageLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="h-screen flex flex-col overflow-hidden relative">
+    <div className="h-dvh flex flex-col overflow-hidden relative">
       <DotPattern />
       <div className="flex-1 overflow-y-auto pt-16 relative z-10">
         <div className="max-w-5xl mx-auto px-4 h-full">{children}</div>


### PR DESCRIPTION
This commit addresses two issues:

1.  **MDX Component Props**: The `pre` and `table` components within the MDX rendering of blog, project, and experience pages were receiving generic `any` types for their props. This commit updates these components to use `React.HTMLAttributes<HTMLPreElement>` and `React.HTMLAttributes<HTMLTableElement>` respectively, providing better type safety and allowing for proper handling of HTML attributes. The `pre` component's children are now correctly typed as a React Element to allow for proper extraction of the code and language.

2.  **Dynamic Viewport Height**: The `h-full` class was replaced with `h-dvh` in `PageLayout.tsx` and `globals.css` to ensure the layout utilizes the dynamic viewport height. This resolves issues where the page height was not correctly adapting to mobile devices with dynamic toolbars, preventing content from being cut off.